### PR TITLE
Fix indexer argument definition

### DIFF
--- a/src/configs/abi_fetcher_config.rs
+++ b/src/configs/abi_fetcher_config.rs
@@ -10,7 +10,7 @@ use crate::chains::chains::get_chains;
     about = "ABI Fetcher for the EVM indexed chains."
 )]
 pub struct EVMAbiFetcherArgs {
-    #[arg(short, long, help = "Start log with debug", default_value_t = false)]
+    #[arg(long, help = "Start log with debug", default_value_t = false)]
     pub debug: bool,
 }
 

--- a/src/configs/indexer_config.rs
+++ b/src/configs/indexer_config.rs
@@ -7,17 +7,16 @@ use clap::Parser;
     about = "A scalable SQL indexer for EVM compatible blockchains."
 )]
 pub struct EVMIndexerArgs {
-    #[arg(short, long, help = "Start log with debug.", default_value_t = false)]
+    #[arg(long, help = "Start log with debug.", default_value_t = false)]
     pub debug: bool,
 
-    #[arg(short, long, help = "Chain name to sync.", default_value_t = String::from("mainnet"))]
+    #[arg(long, help = "Chain name to sync.", default_value_t = String::from("mainnet"))]
     pub chain: String,
 
-    #[arg(short, long, help = "Block to start syncing.", default_value_t = 0)]
+    #[arg(long, help = "Block to start syncing.", default_value_t = 0)]
     pub start_block: i64,
 
     #[arg(
-        short,
         long,
         help = "Amount of blocks to fetch at the same time.",
         default_value_t = 200
@@ -25,20 +24,16 @@ pub struct EVMIndexerArgs {
     pub batch_size: usize,
 
     #[arg(
-        short,
         long,
         help = "Reset a chain to restart the index.",
         default_value_t = false
     )]
     pub reset: bool,
 
-    #[arg(short, long, help = "Websocket to fetch blocks from.")]
+    #[arg(long, help = "Websocket to fetch blocks from.")]
     pub websocket: String,
 
-    #[arg(
-        long,
-        help = "Comma separated list of rpcs to use to fetch blocks."
-    )]
+    #[arg(long, help = "Comma separated list of rpcs to use to fetch blocks.")]
     pub rpcs: String,
 }
 

--- a/src/configs/indexer_config.rs
+++ b/src/configs/indexer_config.rs
@@ -36,7 +36,6 @@ pub struct EVMIndexerArgs {
     pub websocket: String,
 
     #[arg(
-        short,
         long,
         help = "Comma separated list of rpcs to use to fetch blocks."
     )]

--- a/src/configs/parser_config.rs
+++ b/src/configs/parser_config.rs
@@ -6,27 +6,20 @@ use clap::Parser;
     about = "Transaction and Logs parser for the EVM indexer."
 )]
 pub struct EVMParserArgs {
-    #[arg(short, long, help = "Start log with debug", default_value_t = false)]
+    #[arg(long, help = "Start log with debug", default_value_t = false)]
     pub debug: bool,
 
     #[arg(
-        short,
         long,
         help = "Start the llamafolio adapters fetcher",
         default_value_t = false
     )]
     pub llamafolio_adapters: bool,
 
-    #[arg(
-        short,
-        long,
-        help = "Start the erc20 tokens parser",
-        default_value_t = false
-    )]
+    #[arg(long, help = "Start the erc20 tokens parser", default_value_t = false)]
     pub erc20_tokens: bool,
 
     #[arg(
-        short,
         long,
         help = "Start the erc20 balances parser",
         default_value_t = false


### PR DESCRIPTION
This PR removes the short version of the `rpcs` argument, otherwise indexer fails to start with this error 

```
Command EVM Indexer: Short option names must be unique for each argument, but '-r' is in use by both 'reset' and 'rpcs'
```